### PR TITLE
Restrict ISH slice positions that are inside the volume_mask volume.

### DIFF
--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -177,7 +177,8 @@ def compute_average_intensity(
     Compute the average of `intensity` within the volume defined by `volume_mask`.
 
     If `slices` is a non-empty list of slice indices along the x-axis, then the average is
-    restricted to the subvolume of `volume_mask` enclosed by these slices.
+    restricted to the subvolume of `volume_mask` enclosed by these slices. Slices indices outside
+    the `volume_mask` will be ignored.
 
     Args:
         intensity: a float array of shape (W, H, D) where W, H and D are integer dimensions.
@@ -196,6 +197,9 @@ def compute_average_intensity(
         restricted_mask = volume_mask
     else:
         restricted_mask = np.zeros_like(volume_mask)
+        # remove slices indices outside the volume_mask
+        slices = np.delete(slices, np.array(slices) >= volume_mask.shape[0])
+        slices = np.delete(slices, np.array(slices) < 0)
         restricted_mask[slices] = True
         restricted_mask = np.logical_and(restricted_mask, volume_mask)
 

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -198,9 +198,7 @@ def compute_average_intensity(
     else:
         restricted_mask = np.zeros_like(volume_mask)
         # remove slices indices outside the volume_mask
-        slices_ = np.copy(slices)
-        slices_ = np.delete(slices_, slices_ >= volume_mask.shape[0])
-        slices_ = np.delete(slices_, slices_ < 0)
+        slices_ = [slice_ for slice_ in slices if 0 <= slice_ < volume_mask.shape[0]]
         restricted_mask[slices_] = True
         restricted_mask = np.logical_and(restricted_mask, volume_mask)
 

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -198,9 +198,10 @@ def compute_average_intensity(
     else:
         restricted_mask = np.zeros_like(volume_mask)
         # remove slices indices outside the volume_mask
-        slices = np.delete(slices, np.array(slices) >= volume_mask.shape[0])
-        slices = np.delete(slices, np.array(slices) < 0)
-        restricted_mask[slices] = True
+        slices_ = np.copy(slices)
+        slices_ = np.delete(slices_, slices_ >= volume_mask.shape[0])
+        slices_ = np.delete(slices_, slices_ < 0)
+        restricted_mask[slices_] = True
         restricted_mask = np.logical_and(restricted_mask, volume_mask)
 
     if np.any(restricted_mask):

--- a/tests/densities/test_fitting.py
+++ b/tests/densities/test_fitting.py
@@ -219,6 +219,10 @@ def test_compute_average_intensity():
     assert np.allclose(actual, 0.3 / 2.0)
     actual = tested.compute_average_intensity(intensity, volume_mask, slices=[1])
     assert np.allclose(actual, 0.1 / 2.0)
+    actual = tested.compute_average_intensity(intensity, volume_mask, slices=[-1, 1, 3])
+    assert np.allclose(actual, 0.1 / 2.0)
+    actual = tested.compute_average_intensity(intensity, volume_mask, slices=[-1, 3])
+    assert actual == 0
 
 
 def test_compute_average_intensities(hierarchy_info):


### PR DESCRIPTION
Add condition on ISH slices indices during fitting.
Fix #24.