### PR TITLE
Density placement: Force scaling on voxels that are not full. Fix #27.

### DIFF
--- a/atlas_densities/app/cell_densities.py
+++ b/atlas_densities/app/cell_densities.py
@@ -155,7 +155,7 @@ def cell_density(annotation_path, hierarchy_path, nissl_path, output_path):
 
     \b
     - the Nissl stain intensity, which is supposed to represent the overall cell density, up to
-    to region-dependent constant scaling factors.
+    region-dependent constant scaling factors.
     - cell counts from the scientific literature, which are used to determine a local
     linear dependency factor for each region where a cell count is available.
     - the optional soma radii, used to operate a correction.
@@ -417,7 +417,7 @@ def inhibitory_and_excitatory_neuron_densities(
     Note: optimization is not fully implemented and the current process only returns a
     feasible point.
 
-    The ouput densities are saved in the specified output directory under the following
+    The output densities are saved in the specified output directory under the following
     names:
 
     \b
@@ -490,7 +490,7 @@ def compile_measurements(
     Sexual Dimorphism' by Kim et al., 2017.
     https://ars.els-cdn.com/content/image/1-s2.0-S0092867417310693-mmc3.xlsx
     - `atlas_densities/app/data/measurements/gaba_papers.xlsx`, a compilation of measurements
-    from the scientifc literature made by Rodarie Dimitri (BBP).
+    from the scientific literature made by Rodarie Dimitri (BBP).
 
     This command extracts measurements from the above two files and gathers them into a unique
     CSV file with the following columns:
@@ -531,7 +531,7 @@ def compile_measurements(
     See `atlas_densities/densities/excel_reader.py` for more information.
 
     Note: This function should be deprecated once its output has been stored permanently as the
-    the unique source of density-related measurements for the AIBS mouse brain. New measurements
+    unique source of density-related measurements for the AIBS mouse brain. New measurements
     should be added to the stored file (Nexus).
     """
 
@@ -619,7 +619,7 @@ def measurements_to_average_densities(
     If several combinations of measurements yield several average cell densities for the same
     region, then the output data frame records the average of these measurements.
 
-    The ouput average cell densities are saved in under the CSV format as a dataframe with the same
+    The output average cell densities are saved in under the CSV format as a dataframe with the same
     columns as the input data frame specified via `--measurements-path`.
     See :mod:`atlas_densities.app.densities.compile_measurements`.
 
@@ -744,7 +744,7 @@ def fit_average_densities(
     gad67+) in every homogenous region of type "inhibitory".
 
     Our linear fitting of density values relies on the assumption that the average cell density
-    (number of cells per mm^3) of a cell type T in a brain region R depends linearily on the
+    (number of cells per mm^3) of a cell type T in a brain region R depends linearly on the
     average intensity of a gene marker of T. The conversion factor is a constant which depends only
     on T and on which of the following three groups R belongs to:
 
@@ -894,7 +894,7 @@ def inhibitory_neuron_densities(
     (inhibitory neurons) and those of the inhibitory neuron subtypes PV+, SST+ and VIP+.
 
     The function modifies the estimates in `average_densities` (the "first estimates" of the paper)
-    to make them consistent accross cell types: the average density of GAD67+ cells in a leaf
+    to make them consistent across cell types: the average density of GAD67+ cells in a leaf
     region L should be at most the sum of the average densities of its subtypes under scrutiny
     (e.g. PV+, SST+ and VIP+) and should not exceed the neuron density of L.
 

--- a/atlas_densities/densities/excel_reader.py
+++ b/atlas_densities/densities/excel_reader.py
@@ -188,7 +188,7 @@ def _set_metadata_columns(
 
     In `dataframe`, the rows corresponding to the same article have no valid 'source title',
     'comment' nor 'specimen age' except the first one. This function makes sure every row is
-    set with approriate values in the aforementioned columns.
+    set with appropriate values in the aforementioned columns.
 
     Args:
         dataframe: DataFrame obtained when reading the worksheets 'GAD67 densities' or 'PV-SST-VIP'
@@ -352,8 +352,6 @@ def read_inhibitory_neuron_measurement_compilation(
     Read the neuron densities of the worksheet 'GAD67 densities' in gaba_papers.xlsx
 
     Args:
-        region_map: RegionMap object to navigate the brain regions hierarchy.
-            Assumed to be instantiated with AIBS 1.json.
         measurements_path: path to the file gaba_papers.xlsx
 
     Returns:
@@ -361,7 +359,7 @@ def read_inhibitory_neuron_measurement_compilation(
         this module.
     """
 
-    # Reading takes several seconds, possibly due to formulaes interpretation
+    # Reading takes several seconds, possibly due to formulas interpretation
     L.info("Loading excel worksheet ...")
     inhibitory_neurons_worksheet = pd.read_excel(
         str(measurements_path),
@@ -435,8 +433,6 @@ def read_pv_sst_vip_measurement_compilation(measurements_path: Union[str, "Path"
     Read the neuron densities of the worksheet 'PV-SST-VIP' in gaba_papers.xlsx
 
     Args:
-        region_map: RegionMap object to navigate the brain regions hierarchy.
-            Assumed to be instantiated with AIBS 1.json.
         measurements_path: path to the file gaba_papers.xlsx
 
     Returns:
@@ -484,7 +480,7 @@ def read_homogenous_neuron_type_regions(measurements_path: Union[str, "Path"]) -
 
     Returns:
         pd.DataFrame with two columns: 'brain_region' and 'cell_type'. A cell type value
-        is either 'ihibitory' or 'excitatory' and applies to every cell in the region.
+        is either 'inhibitory' or 'excitatory' and applies to every cell in the region.
     """
 
     homogenous_regions_worksheet = pd.read_excel(


### PR DESCRIPTION
While placing cells, the scaling of the intensity can be affected by voxels already full. If too many of them are present, the placement might take too many iterations. See utils.optimize_distance_to_line. Using a filter seems to fix the issue.

Also this fixes minor errors in docstrings.