### PR TITLE
Stop using as many config files

### DIFF
--- a/atlas_densities/app/mtype_densities.py
+++ b/atlas_densities/app/mtype_densities.py
@@ -200,21 +200,18 @@ def _check_config_sanity(config: dict) -> None:
 @app.command()
 @common_atlas_options
 @click.option(
-    "--metadata-path",
+    "--probability-map",
     type=EXISTING_FILE_PATH,
     required=False,
-    help=(
-        "(Optional) Path to the metadata json file. Defaults to "
-        f"`{str(METADATA_REL_PATH / 'isocortex_metadata.json')}`"
-    ),
-    default=str(METADATA_PATH / "isocortex_metadata.json"),
+    #TODOhelp=,
+    default=str(METADATA_PATH / "isocortex_metadata.json"),  #TODO
 )
 @click.option(
-    "--mtypes-config-path",
-    type=EXISTING_FILE_PATH,
+    "--marker",
+    type=(str, EXISTING_FILE_PATH),
+    multiple=True,
     required=True,
-    help="Path to the yaml configuration file. "
-    f"See `{str(MTYPES_PROBABILITY_MAP_REL_PATH / 'README.rst')}` for an example.",
+    help="Name and path to marker: ex: --marker pv path/pv.nrrd"
 )
 @click.option(
     "--output-dir",
@@ -225,8 +222,8 @@ def _check_config_sanity(config: dict) -> None:
 def create_from_probability_map(
     annotation_path,
     hierarchy_path,
-    metadata_path,
-    mtypes_config_path,
+    probability_map,
+    marker,
     output_dir,
 ):  # pylint: disable=too-many-locals
     """
@@ -242,20 +239,11 @@ def create_from_probability_map(
 
     Note: this command does not generate volumetric density files for excitatory neurons.
     """
-    L.info("Loading configuration file ...")
-    with open(mtypes_config_path, "r", encoding="utf-8") as file_:
-        config = yaml.load(file_, Loader=yaml.FullLoader)
-    _check_config_sanity(config)
-
     L.info("Loading probability mapping ...")
-    probability_map = pd.DataFrame(pd.read_csv(config["probabilityMapPath"]))
+    probability_map = pd.read_csv(probability_map)
     probability_map.set_index(["region", "molecular_type"], inplace=True)
 
     check_probability_map_sanity(probability_map)
-
-    L.info("Loading brain region metadata ...")
-    with open(metadata_path, "r", encoding="utf-8") as file_:
-        metadata = json.load(file_)
 
     L.info("Loading hierarchy json file ...")
     region_map = RegionMap.load_json(hierarchy_path)
@@ -266,7 +254,7 @@ def create_from_probability_map(
     L.info("Loading volumetric densities of molecular types ...")
     molecular_type_densities = {
         molecular_type: VoxelData.load_nrrd(density_path)
-        for (molecular_type, density_path) in config["molecularTypeDensityPaths"].items()
+        for molecular_type, density_path in marker
     }
 
     # Check metadata consistency
@@ -277,7 +265,6 @@ def create_from_probability_map(
     create_from_map(
         annotation,
         region_map,
-        metadata,
         {
             molecular_type: density.raw
             for (molecular_type, density) in molecular_type_densities.items()

--- a/atlas_densities/densities/mtype_densities_from_map/create.py
+++ b/atlas_densities/densities/mtype_densities_from_map/create.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 def create_from_probability_map(
     annotation: "VoxelData",
     region_map: "RegionMap",
-    metadata: Dict,
     molecular_type_densities: Dict[str, FloatArray],
     probability_map: "pd.DataFrame",
     output_dirpath: str,
@@ -55,8 +54,6 @@ def create_from_probability_map(
         annotation: VoxelData holding an int array of shape (W, H, D) where W, H and D are integer
             dimensions; this array is the annotated volume of the brain region of interest.
         region_map: RegionMap object to navigate the brain regions hierarchy.
-        metadata: dict describing the regions of interest. See `app/data/metadata`
-            for examples.
         molecular_type_densities: dict whose keys are molecular types (equivalently, gene markers)
             and whose values are 3D float arrays holding the density fields of the cells of the
             corresponding types (i.e., those cells reacting to the corresponding gene markers).
@@ -73,46 +70,22 @@ def create_from_probability_map(
             - the sum of each row of the probability map is different from 1.0
             - the labels of the rows and columns of `probablity_map` are not all lowercase
             or contain some white spaces.
-            - the layer names appearing in the row labels of `probability_map` are not those
-            described in `metadata`
     """
     # pylint: disable=too-many-locals
-    region_ids = []
-    for region in metadata["regions"]:
-        region_ids.extend(
-            [
-                region_id
-                for region_id in region_map.find(
-                    region["query"], region["attribute"], with_descendants=True
-                )
-                if region_map.is_leaf_id(region_id)
-            ]
-        )
-    region_acronyms = [region_map.get(region_id, "acronym") for region_id in region_ids]
-
-    regions_acronyms_diff, molecular_types_diff = _check_probability_map_consistency(
-        probability_map, set(region_acronyms), set(molecular_type_densities.keys())
-    )
-    region_ids = [
-        region_id
-        for region_acronym, region_id in zip(region_acronyms, region_ids)
-        if region_acronym not in regions_acronyms_diff
-    ]
-    region_acronyms = [
-        region_acronym
-        for region_acronym in region_acronyms
-        if region_acronym not in regions_acronyms_diff
-    ]
+    region_info = region_map.as_dataframe().reset_index().set_index('acronym')
+    region_info = region_info.loc[probability_map.index.get_level_values('region')]
+    region_info = region_info.reset_index()[['region', 'id']]
 
     molecular_type_densities = {
         key: value
         for key, value in molecular_type_densities.items()
-        if key not in molecular_types_diff
+        #TODO: need to check consistency of available markers, and what is needed
+        #if key not in molecular_types_diff
     }
 
     region_masks = {
         region_acronym: annotation.raw == region_id
-        for region_acronym, region_id in zip(region_acronyms, region_ids)
+        for _, region_acronym, region_id in region_info.itertuples()
     }
 
     Path(output_dirpath).mkdir(exist_ok=True, parents=True)
@@ -120,7 +93,7 @@ def create_from_probability_map(
     for mtype in tqdm(probability_map.columns):
 
         coefficients: Dict[str, Dict[str, Any]] = {}
-        for region_acronym in region_acronyms:
+        for region_acronym in region_info.region:
             coefficients[region_acronym] = {
                 molecular_type: probability_map.at[(region_acronym, molecular_type), mtype]
                 for molecular_type in list(molecular_type_densities.keys())
@@ -128,7 +101,7 @@ def create_from_probability_map(
             }
 
         mtype_density = np.zeros(annotation.shape, dtype=float)
-        for region_acronym in region_acronyms:
+        for region_acronym in region_info.region:
             region_mask = region_masks[region_acronym]
             for molecular_type, coefficient in coefficients[region_acronym].items():
                 if coefficient <= 0.:


### PR DESCRIPTION
new command line:
    OUTPUT=output/create-from-probability-map
    DATA=../data
    atlas-densities  \
     mtype-densities -vv create-from-probability-map                              \
        --hierarchy-path=$DATA/1.json                                             \
        --annotation-path=$DATA/ccfv2/annotation_25.nrrd                          \
        --probability-map probability_map.csv                                     \
        --marker gad67 $DATA/create-from-probability-map/gad67.nrrd               \
        --marker sst $DATA/create-from-probability-map/sst.nrrd                   \
        --marker vip $DATA/create-from-probability-map/vip.nrrd                   \
        --marker approx_lamp5 $DATA/create-from-probability-map/approx_lamp5.nrrd \
        --marker pv $DATA/create-from-probability-map/pv.nrrd                     \
        --output-dir=$OUTPUT

Thus `--metadata-path` and `--mtypes-config-path` aren't used any more