### PR TITLE
Switch from attribute 'name' to 'acronym'

### DIFF
--- a/atlas_densities/densities/utils.py
+++ b/atlas_densities/densities/utils.py
@@ -361,7 +361,7 @@ def get_group_ids(region_map: "RegionMap", cleanup_rest: bool = False) -> Dict[s
     molecular_layer_ids = cerebellar_cortex_ids & region_map.find(
         "@.*molecular layer", attr="name", with_descendants=True
     )
-    rest_ids = region_map.find("root", attr="name", with_descendants=True)
+    rest_ids = region_map.find("root", attr="acronym", with_descendants=True)
     rest_ids -= cerebellum_group_ids | isocortex_group_ids
 
     if cleanup_rest:
@@ -482,7 +482,7 @@ def get_hierarchy_info(
         every region name.
 
     """
-    region_ids = list(region_map.find(root, attr="name", with_descendants=True))
+    region_ids = list(region_map.find(root, attr="acronym", with_descendants=True))
     region_ids.sort()
     descendant_id_sets = [
         region_map.find(id_, attr="id", with_descendants=True) for id_ in region_ids

--- a/atlas_densities/densities/utils.py
+++ b/atlas_densities/densities/utils.py
@@ -361,7 +361,7 @@ def get_group_ids(region_map: "RegionMap", cleanup_rest: bool = False) -> Dict[s
     molecular_layer_ids = cerebellar_cortex_ids & region_map.find(
         "@.*molecular layer", attr="name", with_descendants=True
     )
-    rest_ids = region_map.find("root", attr="acronym", with_descendants=True)
+    rest_ids = region_map.find("root", attr="name", with_descendants=True)
     rest_ids -= cerebellum_group_ids | isocortex_group_ids
 
     if cleanup_rest:
@@ -456,7 +456,7 @@ def get_aibs_region_names(region_map: "RegionMap") -> Set[str]:
 
 def get_hierarchy_info(
     region_map: "RegionMap",
-    root: str = "Basic cell groups and regions",
+    root: str = "grey",
 ) -> "pd.DataFrame":
     """
     Returns the name and the descendant_id_set of each region that can be found by `region_map`.

--- a/tests/densities/test_inhibitory_neuron_density_optimization.py
+++ b/tests/densities/test_inhibitory_neuron_density_optimization.py
@@ -33,6 +33,7 @@ def get_initialization_data_1():
     hierarchy = {
         "id": 1,
         "name": "root",
+        "acronym": "root",
         "children": [],
     }
 
@@ -84,6 +85,7 @@ def get_initialization_data_2():
     hierarchy = {
         "id": 1,
         "name": "root",
+        "acronym": "root",
         "children": [],
     }
 
@@ -149,9 +151,10 @@ def get_initialization_data_3():
     hierarchy = {
         "id": 8,
         "name": "root",
+        "acronym": "root",
         "children": [
-            {"id": 1, "name": "A", "children": []},
-            {"id": 2, "name": "B", "children": []},
+            {"id": 1, "name": "A", "acronym": "A", "children": []},
+            {"id": 2, "name": "B", "acronym": "B", "children": []},
         ],
     }
 
@@ -218,13 +221,15 @@ def get_initialization_data_4():
     hierarchy = {
         "id": 8,
         "name": "root",
+        "acronym": "root",
         "children": [
             {
                 "id": 1,
                 "name": "A",
+                "acronym": "A",
                 "children": [
-                    {"id": 2, "name": "B", "children": []},
-                    {"id": 3, "name": "C", "children": []},
+                    {"id": 2, "name": "B", "acronym": "B", "children": []},
+                    {"id": 3, "name": "C", "acronym": "C", "children": []},
                 ],
             }
         ],
@@ -275,13 +280,15 @@ def get_initialization_data():
     hierarchy = {
         "id": 8,
         "name": "root",
+        "acronym": "root",
         "children": [
             {
                 "id": 1,
                 "name": "A",
+                "acronym": "A",
                 "children": [
-                    {"id": 2, "name": "B", "children": []},
-                    {"id": 3, "name": "C", "children": []},
+                    {"id": 2, "name": "B", "acronym": "B", "children": []},
+                    {"id": 3, "name": "C", "acronym": "C", "children": []},
                 ],
             }
         ],

--- a/tests/densities/test_measurement_to_density.py
+++ b/tests/densities/test_measurement_to_density.py
@@ -31,9 +31,7 @@ def cell_densities():
 
 
 def test_get_hierarchy_info(region_map):
-    pdt.assert_frame_equal(
-        get_hierarchy_info(), tested.get_hierarchy_info(region_map, root="CENT")
-    )
+    pdt.assert_frame_equal(get_hierarchy_info(), tested.get_hierarchy_info(region_map, root="CENT"))
 
 
 def test_get_parent_region(region_map):

--- a/tests/densities/test_measurement_to_density.py
+++ b/tests/densities/test_measurement_to_density.py
@@ -32,7 +32,7 @@ def cell_densities():
 
 def test_get_hierarchy_info(region_map):
     pdt.assert_frame_equal(
-        get_hierarchy_info(), tested.get_hierarchy_info(region_map, root="Central lobule")
+        get_hierarchy_info(), tested.get_hierarchy_info(region_map, root="CENT")
     )
 
 

--- a/tests/densities/test_refined_inhibitory_neuron_density.py
+++ b/tests/densities/test_refined_inhibitory_neuron_density.py
@@ -334,15 +334,18 @@ def get_inhibitory_neuron_densities_data():
     return {
         "hierarchy": {
             "name": "root",
+            "acronym": "root",
             "id": 3,
             "children": [
                 {
                     "name": "A",
+                    "acronym": "A",
                     "id": 1,
                     "children": [],
                 },
                 {
                     "name": "B",
+                    "acronym": "B",
                     "id": 2,
                 },
             ],

--- a/tests/densities/test_utils.py
+++ b/tests/densities/test_utils.py
@@ -341,7 +341,7 @@ def get_hierarchy_info():
 
 def test_get_hierarchy(region_map):
     pdt.assert_frame_equal(
-        pd.DataFrame(tested.get_hierarchy_info(region_map, root="Central lobule")),
+        pd.DataFrame(tested.get_hierarchy_info(region_map, root="CENT")),
         get_hierarchy_info(),
     )
 


### PR DESCRIPTION
As of https://bbpteam.epfl.ch/project/issues/browse/BBPP134-36, the `name` of the root region changed from "root" to "Whole Mouse Brain".
`acronym` is already used [here](https://github.com/BlueBrain/atlas-densities/blob/16981b5d244d9cdde82ed6b098564f8296c2dbfa/atlas_densities/combination/annotations_combinator.py#L48).