### PR TITLE
Allow specifying the "root" name

### DIFF
--- a/atlas_densities/app/cell_densities.py
+++ b/atlas_densities/app/cell_densities.py
@@ -140,8 +140,14 @@ def app(verbose):
     help="Path where to write the output cell density nrrd file."
     "A voxel value is a number of cells per mm^3",
 )
+@click.option(
+    "--root-region-name",
+    type=str,
+    default="root",
+    help="Name of the region in the hierarchy",
+)
 @log_args(L)
-def cell_density(annotation_path, hierarchy_path, nissl_path, output_path):
+def cell_density(annotation_path, hierarchy_path, nissl_path, output_path, root_region_name):
     """Compute and save the overall mouse brain cell density.
 
     The input Nissl stain volume of AIBS is turned into an actual density field complying with
@@ -174,6 +180,7 @@ def cell_density(annotation_path, hierarchy_path, nissl_path, output_path):
         annotation.raw,
         _get_voxel_volume_in_mm3(annotation),
         nissl.raw,
+        root_region_name=root_region_name,
     )
     nissl.with_data(overall_cell_density).save_nrrd(output_path)
 
@@ -380,6 +387,12 @@ def glia_cell_densities(
     help="Path to the directory where to write the output cell density nrrd files."
     " It will be created if it doesn't exist already.",
 )
+@click.option(
+    "--root-region-name",
+    type=str,
+    default="root",
+    help="Name of the region in the hierarchy",
+)
 @log_args(L)
 def inhibitory_and_excitatory_neuron_densities(
     annotation_path,
@@ -389,6 +402,7 @@ def inhibitory_and_excitatory_neuron_densities(
     neuron_density_path,
     inhibitory_neuron_counts_path,
     output_dir,
+    root_region_name,
 ):  # pylint: disable=too-many-arguments
     """Compute and save the inhibitory and excitatory neuron densities.
 
@@ -442,6 +456,7 @@ def inhibitory_and_excitatory_neuron_densities(
         VoxelData.load_nrrd(nrn1_path).raw,
         neuron_density.raw,
         inhibitory_data=inhibitory_data(inhibitory_df),
+        root_region_name=root_region_name,
     )
 
     if not Path(output_dir).exists():

--- a/atlas_densities/densities/cell_density.py
+++ b/atlas_densities/densities/cell_density.py
@@ -6,13 +6,8 @@ import numpy as np
 from atlas_commons.typing import AnnotationT, BoolArray, FloatArray
 from voxcell import RegionMap  # type: ignore
 
+from atlas_densities.densities import utils
 from atlas_densities.densities.cell_counts import cell_counts
-from atlas_densities.densities.utils import (
-    compensate_cell_overlap,
-    get_group_ids,
-    get_region_masks,
-    normalize_intensity,
-)
 
 
 def fix_purkinje_layer_intensity(
@@ -64,6 +59,7 @@ def compute_cell_density(
     annotation: AnnotationT,
     voxel_volume: float,
     nissl: FloatArray,
+    root_region_name: str,
 ) -> FloatArray:
     """
     Compute the overall cell density based on Nissl staining and cell counts from literature.
@@ -101,11 +97,11 @@ def compute_cell_density(
     """
 
     nissl = np.asarray(nissl, dtype=np.float64)
-    nissl = normalize_intensity(nissl, annotation, threshold_scale_factor=1.0, copy=False)
-    nissl = compensate_cell_overlap(nissl, annotation, gaussian_filter_stdv=-1.0, copy=False)
+    nissl = utils.normalize_intensity(nissl, annotation, threshold_scale_factor=1.0, copy=False)
+    nissl = utils.compensate_cell_overlap(nissl, annotation, gaussian_filter_stdv=-1.0, copy=False)
 
-    group_ids = get_group_ids(region_map)
-    region_masks = get_region_masks(group_ids, annotation)
+    group_ids = utils.get_group_ids(region_map, root_region_name=root_region_name)
+    region_masks = utils.get_region_masks(group_ids, annotation)
     fix_purkinje_layer_intensity(group_ids, annotation, region_masks, nissl)
     non_zero_nissl = nissl > 0
     for group, mask in region_masks.items():

--- a/atlas_densities/densities/cell_density.py
+++ b/atlas_densities/densities/cell_density.py
@@ -1,7 +1,6 @@
 """Functions to compute the overall mouse brain cell density.
 """
-
-from typing import Dict
+from __future__ import annotations
 
 import numpy as np
 from atlas_commons.typing import AnnotationT, BoolArray, FloatArray
@@ -17,9 +16,9 @@ from atlas_densities.densities.utils import (
 
 
 def fix_purkinje_layer_intensity(
-    region_map: "RegionMap",
+    group_ids: dict[str, set[int]],
     annotation: AnnotationT,
-    region_masks: Dict[str, BoolArray],
+    region_masks: dict[str, BoolArray],
     cell_intensity: FloatArray,
 ) -> None:
     """
@@ -29,7 +28,8 @@ def fix_purkinje_layer_intensity(
     The array `cell_intensity` is modified in place.
 
     Args:
-        region_map: object to navigate the mouse brain regions hierarchy.
+        group_ids: a dictionary whose keys are group names and whose values are
+            sets of AIBS structure identifiers.
         annotation: integer array of shape (W, H, D) enclosing the AIBS annotation of
             the whole mouse brain.
         region_masks: A dictionary whose keys are region group names and whose values are
@@ -40,8 +40,8 @@ def fix_purkinje_layer_intensity(
             way that the Purkinje layer has a constant intensity value.
     """
 
-    group_ids = get_group_ids(region_map)
     purkinje_layer_mask = np.isin(annotation, list(group_ids["Purkinje layer"]))
+
     # Force Purkinje Layer regions of the Cerebellum group to have a constant intensity
     # equal to the average intensity of the complement.
     # pylint: disable=fixme
@@ -106,7 +106,7 @@ def compute_cell_density(
 
     group_ids = get_group_ids(region_map)
     region_masks = get_region_masks(group_ids, annotation)
-    fix_purkinje_layer_intensity(region_map, annotation, region_masks, nissl)
+    fix_purkinje_layer_intensity(group_ids, annotation, region_masks, nissl)
     non_zero_nissl = nissl > 0
     for group, mask in region_masks.items():
         mask = np.logical_and(non_zero_nissl, mask)

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -620,7 +620,7 @@ def linear_fitting(  # pylint: disable=too-many-arguments
 
     L.info("Getting group names ...")
     # We want group region names to be stable under taking descendants
-    groups = get_group_names(region_map, cleanup_rest=True)
+    groups = get_group_names(region_map, cleanup_rest=True, root_region_name=region_name)
 
     L.info("Computing fitting coefficients ...")
     fitting_coefficients = compute_fitting_coefficients(groups, average_intensities, densities)

--- a/atlas_densities/densities/inhibitory_neuron_density.py
+++ b/atlas_densities/densities/inhibitory_neuron_density.py
@@ -89,6 +89,7 @@ def compute_inhibitory_neuron_density(  # pylint: disable=too-many-arguments
     neuron_density: FloatArray,
     inhibitory_proportion: Optional[float] = None,
     inhibitory_data: Optional[InhibitoryData] = None,
+    root_region_name: Optional[str] = None,
 ) -> FloatArray:
     """
     Compute the inhibitory neuron density using a prescribed neuron count and the overall neuron
@@ -115,6 +116,7 @@ def compute_inhibitory_neuron_density(  # pylint: disable=too-many-arguments
                 assigning the proportion of ihnibitory neurons in each group named by a key string.
             'neuron_count': the total number of inhibitory neurons (float).
             Used only if `inhibitory_proportion` is None.
+        root_region_name(str): Name of the root region in the hierarchy
 
     Returns:
         float64 array of shape (W, H, D) with non-negative entries.
@@ -138,7 +140,7 @@ def compute_inhibitory_neuron_density(  # pylint: disable=too-many-arguments
                 "Either inhibitory_proportion or inhibitory_data should be provided"
                 ". Both are None."
             )
-        group_ids = get_group_ids(region_map)
+        group_ids = get_group_ids(region_map, root_region_name=root_region_name)
         inhibitory_data["region_masks"] = get_region_masks(group_ids, annotation)
     else:
         inhibitory_data = {

--- a/tests/densities/test_cell_density.py
+++ b/tests/densities/test_cell_density.py
@@ -89,7 +89,7 @@ def test_cell_density_options():
         actual = tested.compute_cell_density(region_map, annotation, voxel_volume, nissl)
         expected_intensity = nissl.copy()
         tested.fix_purkinje_layer_intensity(
-            region_map, annotation, cell_counts(), expected_intensity
+            group_ids, annotation, cell_counts(), expected_intensity
         )
         for group, mask in region_masks.items():
             expected_intensity[mask] = nissl[mask] * (cell_counts()[group] / np.sum(nissl[mask]))

--- a/tests/densities/test_cell_density.py
+++ b/tests/densities/test_cell_density.py
@@ -25,9 +25,15 @@ def test_compute_cell_density():
     nissl = rng.random(annotation.shape)
     nissl[0][0][0] = 1e-5  # the outside voxels' intensity should be low
 
-    cell_density = tested.compute_cell_density(region_map, annotation, voxel_volume, nissl)
+    cell_density = tested.compute_cell_density(
+        region_map,
+        annotation,
+        voxel_volume,
+        nissl,
+        root_region_name="root",
+    )
     # Each group has a prescribed cell count
-    group_ids = get_group_ids(region_map)
+    group_ids = get_group_ids(region_map, root_region_name="root")
     region_masks = get_region_masks(group_ids, annotation)
     for group, mask in region_masks.items():
         npt.assert_array_almost_equal(
@@ -55,9 +61,10 @@ def test_cell_density_with_soma_correction():
         annotation,
         voxel_volume,
         nissl,
+        root_region_name="root",
     )
     # Each group has a prescribed cell count
-    group_ids = get_group_ids(region_map)
+    group_ids = get_group_ids(region_map, root_region_name="root")
     region_masks = get_region_masks(group_ids, annotation)
     for group, mask in region_masks.items():
         npt.assert_array_almost_equal(
@@ -79,14 +86,20 @@ def test_cell_density_options():
     rng = np.random.default_rng(seed=42)
     nissl = rng.random(annotation.shape)
     nissl[0][0][0] = 1e-5  # the outside voxels' intensity should be low
-    group_ids = get_group_ids(region_map)
+    group_ids = get_group_ids(region_map, root_region_name="root")
     region_masks = get_region_masks(group_ids, annotation)
 
     with patch(
-        "atlas_densities.densities.cell_density.compensate_cell_overlap",
+        "atlas_densities.densities.utils.compensate_cell_overlap",
         return_value=nissl,
     ):
-        actual = tested.compute_cell_density(region_map, annotation, voxel_volume, nissl)
+        actual = tested.compute_cell_density(
+            region_map,
+            annotation,
+            voxel_volume,
+            nissl,
+            root_region_name="root",
+        )
         expected_intensity = nissl.copy()
         tested.fix_purkinje_layer_intensity(
             group_ids, annotation, cell_counts(), expected_intensity

--- a/tests/densities/test_fitting.py
+++ b/tests/densities/test_fitting.py
@@ -423,6 +423,25 @@ def get_hierarchy():
                 "name": "Hippocampal formation",
                 "children": [],
             },
+            {
+                "id": 42,
+                "acronym": "PKL",
+                "name": "Purkinje layer",
+                "children": [],
+            },
+            {
+                "id": 38,
+                "acronym": "CCTX",
+                "name": "Cerebellar cortex",
+                "children": [
+                    {
+                        "id": 37,
+                        "acronym": "MLL",
+                        "name": "molecular layer",
+                        "children": [],
+                    },
+                ],
+            },
         ],
     }
 
@@ -494,7 +513,7 @@ def test_linear_fitting():
         )
         warnings_ = [w for w in warnings_ if isinstance(w.message, AtlasDensitiesWarning)]
         # Three warnings for recording NaN coefficients, three warnings for using them
-        assert len(warnings_) == 6
+        assert len(warnings_) == 9
 
     assert np.allclose(fitting_maps["Rest"]["pv+"]["coefficient"], 2.0 / 3.0)
 

--- a/tests/densities/test_glia_densities.py
+++ b/tests/densities/test_glia_densities.py
@@ -26,7 +26,7 @@ def test_compute_glia_cell_counts_per_voxel():
                 },
                 {
                     "id": 3,
-                    "name": "3 Fiber tracts group",
+                    "name": "fiber tracts",
                     "acronym": "ft3",
                     "children": [
                         {"id": 6, "name": "6 fiber tracts group", "acronym": "tf6", "children": []}

--- a/tests/densities/test_inhibitory_neuron_density.py
+++ b/tests/densities/test_inhibitory_neuron_density.py
@@ -97,6 +97,7 @@ def test_compute_inhibitory_neuron_density():
                     data["nrn1"],
                     neuron_density,
                     inhibitory_data=data["inhibitory_data"],
+                    root_region_name="root",
                 )
                 expected = np.array([[[0.0, 0.0, 4.0, 25.0 / 62.0, 99.0 / 62.0]]]) / voxel_volume
                 npt.assert_almost_equal(inhibitory_neuron_density, expected)
@@ -112,6 +113,7 @@ def test_compute_inhibitory_neuron_density_exception():
             np.array([[[1]]], dtype=float),
             np.array([[[1]]], dtype=float),
             np.array([[[1]]], dtype=float),
+            root_region_name="root",
         )
     assert "inhibitory_proportion" in str(error_)
     assert "inhibitory_data" in str(error_)
@@ -160,6 +162,7 @@ def test_compute_inhibitory_density_large_input():
         data["nrn1"],
         data["neuron_density"],
         inhibitory_data=data["inhibitory_data"],
+        root_region_name="root",
     )
 
     assert np.all(inhibitory_neuron_density <= data["neuron_density"])

--- a/tests/densities/test_utils.py
+++ b/tests/densities/test_utils.py
@@ -101,7 +101,7 @@ def test_compensate_cell_overlap():
 
 def test_get_group_ids():
     region_map = RegionMap.load_json(Path(TESTS_PATH, "1.json"))
-    group_ids = tested.get_group_ids(region_map)
+    group_ids = tested.get_group_ids(region_map, root_region_name="root")
     for ids in group_ids.values():
         assert len(ids) > 0
     assert len(group_ids["Molecular layer"] & group_ids["Purkinje layer"]) == 0
@@ -117,7 +117,7 @@ def test_get_group_ids():
 
 def test_get_region_masks():
     region_map = RegionMap.load_json(Path(TESTS_PATH, "1.json"))
-    group_ids = tested.get_group_ids(region_map)
+    group_ids = tested.get_group_ids(region_map, root_region_name="root")
     annotation_raw = np.arange(27000).reshape(30, 30, 30)
     region_masks = tested.get_region_masks(group_ids, annotation_raw)
     brain_mask = np.logical_or(


### PR DESCRIPTION
For the `cell-densities cell-density` and `cell-densities  inhibitory_and_excitatory_neuron_densities` commands.  It defaults to "root", like for the AIBS hierarchy, if not specified.