### PR TITLE
Drop literature values from regions that are not in hierarchy or not in the annotation volume

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ The outcome of this project is a list of volumetric files that provides cell typ
 for each voxel of the mouse brain volume. The BBP Cell Atlas is the first model required to
 reconstruct BBP circuits of the mouse brain.
 
-The tools implementation is based on the methods of `Eroe et al. (2018)`_, `Rodarie et al. (2021)`_,
-and `Roussel et al. (2021)`_.
+The tools implementation is based on the methods of `Eroe et al. (2018)`_, `Rodarie et al. (2022)`_,
+and `Roussel et al. (2022)`_.
 
 The source code was originally written by Csaba Eroe, Dimitri Rodarie, Hugo Dictus, Lu Huanxiang,
 Wojciech Wajerowicz, Jonathan Lurie, and Yann Roussel.
@@ -53,7 +53,7 @@ Note: Depending on the size and resolution of the atlas, it can happen that some
 Reference atlases
 -----------------
 
-Most the pipeline steps rely on the following AIBS reference datasets (see `Rodarie et al. (2021)`_ for more
+Most the pipeline steps rely on the following AIBS reference datasets (see `Rodarie et al. (2022)`_ for more
 details on the different versions of these datasets):
 
 * A Nissl volume
@@ -161,7 +161,7 @@ ISH datasets for inhibitory/excitatory neurons
 In `Eroe et al. (2018)`_ (i.e., BBP Cell Atlas version 1), the excitatory neurons are distinguished
 from the inhibitory neurons using the Nrn1 and GAD67 (or GAD1) genetic marker.
 
-In `Rodarie et al. (2021)`_ (i.e., BBP Cell Atlas version 2), the authors used parvalbumin (Pvalb),
+In `Rodarie et al. (2022)`_ (i.e., BBP Cell Atlas version 2), the authors used parvalbumin (Pvalb),
 somatostatin (SST), vasoactive intestinal peptide (VIP) and gabaergic (GAD1) markers (see also
 `fit_average_densities_ccfv2_config.yaml`_).
 
@@ -207,7 +207,7 @@ The files `glia.nrrd`, `oligodendrocyte.nrrd`, `microglia.nrrd`, `astrocyte.nrrd
 Extract literature neuron type densities estimates
 --------------------------------------------------
 
-In `Rodarie et al. (2021)`_, the authors collected density estimates from the literature for
+In `Rodarie et al. (2022)`_, the authors collected density estimates from the literature for
 inhibitory neurons. Some estimates are in a format that can not be directly used by the pipeline
 (e.g., counts instead of densities). This part of the pipeline integrates the literature values into
 csv files, that will be used later on for the fitting.
@@ -216,7 +216,7 @@ Format literature review files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We compile here the cell density estimates related to measurements of `Kim et al. (2017)`_ density
-file (`mmc3.xlsx`_) and `Rodarie et al. (2021)`_ literature
+file (`mmc3.xlsx`_) and `Rodarie et al. (2022)`_ literature
 review file (`gaba_papers.xlsx`_) into a single CSV file.
 Regions known to be purely excitatory or inhibitory (in terms of neuron composition) are also listed
 in a separate CSV file.
@@ -237,6 +237,13 @@ Convert literature measurements into average densities
 Compute and save average cell densities based on literature measurements and Cell Atlas data (e.g.,
 region volumes).
 
+WARNING:
+Different versions of the annotation atlas or the hierarchy file might have different sets brain
+regions (see `Rodarie et al. (2022)`_ for more details). The region names used by the literature
+measurements might therefore have no match in these datasets.
+Regions from the measurements that are not in the hierarchy or do not appear in the annotations will
+be ignored. A warning message will display these regions, allowing us to review them.
+
 .. code-block:: bash
 
     atlas-densities cell-densities measurements-to-average-densities         \
@@ -252,7 +259,7 @@ Fit transfer functions from mean region intensity to neuron density
 -------------------------------------------------------------------
 
 We fit here transfer functions that describe the relation between mean ISH expression in regions of
-the mouse brain and literature regional density estimates (see `Rodarie et al. (2021)`_ for more
+the mouse brain and literature regional density estimates (see `Rodarie et al. (2022)`_ for more
 details). This step leverages AIBS ISH marker datasets (in their expression form, see also
 `fit_average_densities_ccfv2_config.yaml`_) and the previously computed
 literature density values.
@@ -281,7 +288,7 @@ Compute inhibitory/excitatory neuron densities
 ----------------------------------------------
 
 The neuron subtypes are here distinguished from each other using either the pipeline from
-`Eroe et al. (2018)`_ (BBP Cell Atlas version 1) or `Rodarie et al. (2021)`_ (BBP Cell Atlas version
+`Eroe et al. (2018)`_ (BBP Cell Atlas version 1) or `Rodarie et al. (2022)`_ (BBP Cell Atlas version
 2).
 
 BBP Cell Atlas version 1
@@ -321,8 +328,8 @@ Compute ME-types densities from a probability map
 -------------------------------------------------
 
 Morphological and Electrical type densities of inhibitory neurons in the isocortex can be estimated
-using Roussel et al.'s pipeline. This pipeline produces a mapping from inhibitory neuron molecular
-types (here PV, SST, VIP and GAD67) to ME-types defined in `Markram et al. (2015)`_.
+using `Roussel et al. (2022)`_'s pipeline. This pipeline produces a mapping from inhibitory neuron
+molecular types (here PV, SST, VIP and GAD67) to ME-types defined in `Markram et al. (2015)`_.
 
 The following command creates neuron density nrrd files for the me-types listed in a probability
 mapping csv file (see also `mtypes_probability_map_config.yaml`_).
@@ -431,8 +438,8 @@ Copyright © 2022 Blue Brain Project/EPFL
 .. _`Eroe et al. (2018)`: https://www.frontiersin.org/articles/10.3389/fninf.2018.00084/full
 .. _`Kim et al. (2017)`: https://www.sciencedirect.com/science/article/pii/S0092867417310693
 .. _`Markram et al. (2015)`: https://www.cell.com/cell/fulltext/S0092-8674(15)01191-5
-.. _`Rodarie et al. (2021)`: https://www.biorxiv.org/content/10.1101/2021.11.20.469384v2
-.. _`Roussel et al. (2021)`: https://www.biorxiv.org/content/10.1101/2021.11.24.469815v1
+.. _`Rodarie et al. (2022)`: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010739
+.. _`Roussel et al. (2022)`: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010058
 .. _`BBP Cell Atlas`: https://portal.bluebrain.epfl.ch/resources/models/cell-atlas/
 .. _cgal-pybind: https://github.com/BlueBrain/cgal-pybind
 .. _`DeepAtlas`: https://github.com/BlueBrain/Deep-Atlas

--- a/atlas_densities/app/cell_densities.py
+++ b/atlas_densities/app/cell_densities.py
@@ -742,7 +742,7 @@ def measurements_to_average_densities(
     "--region-name",
     type=str,
     default="root",
-    help="Name of the region in the hierarchy",
+    help="Name of the root region in the hierarchy",
 )
 @click.option(
     "--neuron-density-path",
@@ -912,8 +912,8 @@ def fit_average_densities(
     L.info("Loading average densities dataframe ...")
     average_densities_df = pd.read_csv(average_densities_path)
     homogenous_regions_df = pd.read_csv(homogenous_regions_path)
-    remove_unknown_regions(average_densities_df, region_map, annotation.raw)
-    remove_unknown_regions(homogenous_regions_df, region_map, annotation.raw)
+    remove_unknown_regions(average_densities_df, region_map, annotation.raw, root=region_name)
+    remove_unknown_regions(homogenous_regions_df, region_map, annotation.raw, root=region_name)
 
     L.info("Fitting of average densities: started")
     fitted_densities_df, fitting_maps = linear_fitting(
@@ -945,7 +945,7 @@ def fit_average_densities(
     "--region-name",
     type=str,
     default="root",
-    help="Name of the region in the hierarchy",
+    help="Name of the root region in the hierarchy",
 )
 @click.option(
     "--neuron-density-path",

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -29,6 +29,7 @@ from scipy.optimize import curve_fit
 from tqdm import tqdm
 
 from atlas_densities.densities import utils
+from atlas_densities.densities.measurement_to_density import remove_unknown_regions
 from atlas_densities.exceptions import AtlasDensitiesError, AtlasDensitiesWarning
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -625,6 +626,9 @@ def linear_fitting(  # pylint: disable=too-many-arguments
     _check_homogenous_regions_sanity(homogenous_regions)
 
     hierarchy_info = utils.get_hierarchy_info(region_map, root=region_name)
+    remove_unknown_regions(average_densities, region_map, annotation, hierarchy_info)
+    remove_unknown_regions(homogenous_regions, region_map, annotation, hierarchy_info)
+
     L.info("Creating a data frame from known densities ...")
     densities = create_dataframe_from_known_densities(
         hierarchy_info["brain_region"].to_list(), average_densities

--- a/atlas_densities/densities/measurement_to_density.py
+++ b/atlas_densities/densities/measurement_to_density.py
@@ -258,7 +258,10 @@ def cell_count_per_slice_to_density(
 
 
 def remove_unknown_regions(
-    measurements: "pd.DataFrame", region_map: RegionMap, annotation: AnnotationT
+    measurements: "pd.DataFrame",
+    region_map: RegionMap,
+    annotation: AnnotationT,
+    root: str = "root",
 ):
     """
     Drop lines from the measurements dataframe which brain regions are not in the AIBS brain region
@@ -271,8 +274,9 @@ def remove_unknown_regions(
         region_map: RegionMap object to navigate the brain regions hierarchy.
         annotation: int array of shape (W, H, D) holding the annotation of the whole AIBS
             mouse brain. (The integers W, H and D are the dimensions of the array).
+        root: name of the root region to consider in the hierarchy.
     """
-    hierarchy_info = get_hierarchy_info(region_map)
+    hierarchy_info = get_hierarchy_info(region_map, root)
     pd.set_option("display.max_colwidth", None)
     indices_ids = measurements.index[
         ~measurements["brain_region"].isin(hierarchy_info["brain_region"])
@@ -284,7 +288,7 @@ def remove_unknown_regions(
             f"{measurements.loc[indices_ids, 'brain_region'].to_string()}",
             AtlasDensitiesWarning,
         )
-    measurements.drop(indices_ids, inplace=True)
+        measurements.drop(indices_ids, inplace=True)
 
     u_regions = np.unique(annotation)
     u_regions = np.delete(u_regions, 0)  # don't take 0, i.e: outside of the brain
@@ -302,7 +306,7 @@ def remove_unknown_regions(
             f"annotation volume: \n{measurements.loc[indices_ann, 'brain_region'].to_string()}",
             AtlasDensitiesWarning,
         )
-    measurements.drop(indices_ann, inplace=True)
+        measurements.drop(indices_ann, inplace=True)
 
 
 def measurement_to_average_density(

--- a/tests/app/test_cell_densities.py
+++ b/tests/app/test_cell_densities.py
@@ -271,6 +271,8 @@ def _get_measurements_to_average_densities_result(runner, hierarchy_path, measur
         hierarchy_path,
         "--annotation-path",
         "annotation.nrrd",
+        "--region-name",
+        "Basic cell groups and regions",
         "--cell-density-path",
         "cell_density.nrrd",
         "--neuron-density-path",

--- a/tests/densities/test_measurement_to_density.py
+++ b/tests/densities/test_measurement_to_density.py
@@ -75,9 +75,7 @@ def test_remove_unknown_regions(region_map, annotations):
             "source_title": ["Article 1", "Article 2", "Article 1"],
         }
     )
-    tested.remove_unknown_regions(
-        measurements, region_map, annotations, root="Basic cell groups and regions"
-    )
+    tested.remove_unknown_regions(measurements, region_map, annotations, get_hierarchy_info())
     expected = pd.DataFrame(
         {
             "brain_region": [

--- a/tests/densities/test_measurement_to_density.py
+++ b/tests/densities/test_measurement_to_density.py
@@ -75,7 +75,9 @@ def test_remove_unknown_regions(region_map, annotations):
             "source_title": ["Article 1", "Article 2", "Article 1"],
         }
     )
-    tested.remove_unknown_regions(measurements, region_map, annotations)
+    tested.remove_unknown_regions(
+        measurements, region_map, annotations, root="Basic cell groups and regions"
+    )
     expected = pd.DataFrame(
         {
             "brain_region": [


### PR DESCRIPTION
Fix #60.
Regions dropped will be displayed with a warning.
Update README.rst