### PR TITLE
Faster compute average intensities

### DIFF
--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -337,7 +337,7 @@ def compute_average_intensities(
             continue
         work.append(_helper(annotation, gene_marker_volumes, id_))
 
-    res = Parallel(n_jobs=-2)(work)
+    res = Parallel()(work)
     densities = (
         pd.DataFrame(list(it.chain(*res)), columns=["marker", "id", "voxel_count", "density"])
         .set_index("id")

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 import numpy as np
 import pandas as pd
 from atlas_commons.typing import AnnotationT, BoolArray, FloatArray
-from joblib import Parallel, delayed
 from scipy.optimize import curve_fit
 from tqdm import tqdm
 
@@ -273,23 +272,82 @@ def _apply_density_slices(gene_marker_volumes):
     return ret
 
 
-def _compute_average_intensities_helper(annotation, gene_marker_volumes, id_):
+def _compute_average_intensities_helper(index, gene_marker_volumes, id_):
     """Compute the average intensity for `id_`, for all makers in `gene_marker_volumes`"""
-    mask = annotation == id_
+    voxel_ids = index.value_to_1d_indices(id_)
+
     res = []
     for marker, intensity in gene_marker_volumes.items():
-        restricted_mask = np.logical_and(intensity["mask"], mask)
-        count = restricted_mask.sum()
+        mask_voxels = index.ravel(intensity["mask"])[voxel_ids]
+
+        count = mask_voxels.sum()
 
         if count <= 0:
             continue
 
-        mean_density = np.mean(intensity["intensity"][restricted_mask])
+        mean_density = index.ravel(intensity["intensity"])[voxel_ids][mask_voxels].sum() / count
+
         if mean_density == 0.0:
             L.warning("Mean density for id=%s and marker=%s", id_, marker)
         res.append((marker.lower(), id_, count, mean_density))
 
     return res
+
+
+class ValueToIndexVoxels:
+    """Efficient access to indices of unique values of the values array.
+
+    Useful for when one has an "annotations volume" or "brain region volume" that has
+    regions indicated by unique values, and these are used to create masks.  Often,
+    it's faster to avoid mask creation, and use indices directly
+
+    Example:
+        vtiv = ValueToIndexVoxels(br.raw)
+        values, funcs = zip(*((i, np.sum if i % 2 else np.mean) for i in vtiv.values[:10]))
+        list(vtiv.apply(values, funcs, density.raw))
+    """
+
+    def __init__(self, values):
+        """Initialize.
+
+        Args:
+            values(np.array): volume with each voxel marked with a value; usually to group regions
+        """
+        self._order = "C" if values.flags["C_CONTIGUOUS"] else "F"
+
+        values = values.ravel(order=self._order)
+        uniques, codes, counts = np.unique(values, return_inverse=True, return_counts=True)
+
+        offsets = np.empty(len(counts) + 1, dtype=np.uint64)
+        offsets[0] = 0
+        offsets[1:] = np.cumsum(counts)
+
+        self._codes = codes
+        self._offsets = offsets
+        self._indices = np.argsort(values, kind="stable")
+        self._mapping = {v: i for i, v in enumerate(uniques)}
+        self.index_dtype = values.dtype
+
+    def ravel(self, voxel_data):
+        """Ensures `voxel_data` matches the layout that the 1D indices can be used."""
+        return voxel_data.ravel(order=self._order)
+
+    @property
+    def values(self):
+        """Unique values that are found in the original volume."""
+        return np.fromiter(self._mapping, dtype=self.index_dtype)
+
+    def value_to_1d_indices(self, value):
+        """Return the indices array indices corresponding to the 'value'.
+
+        Note: These are 1D indices, so the assumption is they are applied to a volume
+        who has been ValueToIndexVoxels::ravel(volume)
+        """
+        if value not in self._mapping:
+            return np.array([], dtype=np.uint64)
+
+        group_index = self._mapping[value]
+        return self._indices[self._offsets[group_index] : self._offsets[group_index + 1]]
 
 
 def compute_average_intensities(
@@ -330,14 +388,16 @@ def compute_average_intensities(
     """
     gene_marker_volumes = _apply_density_slices(gene_marker_volumes)
 
-    _helper = delayed(_compute_average_intensities_helper)
+    index = ValueToIndexVoxels(annotation)
+
+    _helper = _compute_average_intensities_helper
     work = []
-    for id_ in np.unique(annotation):
+    for id_ in index.values:
         if id_ == 0:
             continue
-        work.append(_helper(annotation, gene_marker_volumes, id_))
+        work.append(_helper(index, gene_marker_volumes, id_))
 
-    res = Parallel()(work)
+    res = work
     densities = (
         pd.DataFrame(list(it.chain(*res)), columns=["marker", "id", "voxel_count", "density"])
         .set_index("id")

--- a/atlas_densities/densities/fitting.py
+++ b/atlas_densities/densities/fitting.py
@@ -324,8 +324,6 @@ def compute_average_intensities(
     region_map_df = region_map.as_dataframe()
     add_depths(region_map_df)
 
-    #hierarchy_info = hierarchy_info.set_index("brain_region")
-    #gene_marker_volumes = ['gad67', 'pv', 'sst', 'vip']
     result = pd.DataFrame(
         data=np.nan,
         index=hierarchy_info.index,
@@ -340,94 +338,6 @@ def compute_average_intensities(
         result[marker.lower()] = df['density']
 
     result = result.set_index('name')
-    return result
-
-
-'''
-from atlas_densities.densities import fitting
-from voxcell import VoxelData, RegionMap
-from atlas_densities.densities import utils
-
-annotation = VoxelData.load_nrrd('input-data/annotation_ccfv2_l23split_barrelsplit_validated.nrrd')
-
-gene_voxeldata = {
-    'gad67': VoxelData.load_nrrd('input-data/gene_gad67_correctednissl.nrrd'),
-    'pv': VoxelData.load_nrrd('input-data/gene_pv_correctednissl.nrrd'),
-    'sst': VoxelData.load_nrrd('input-data/gene_sst_correctednissl.nrrd'),
-    'vip': VoxelData.load_nrrd('input-data/gene_vip_correctednissl.nrrd'),
-}
-gids = { 'gad67': '479', 'pv': '868', 'sst': '1001', 'vip': '77371835', }
-slices = utils.load_json('input-data/realigned_slices.json')
-gene_marker_volumes = {
-    gene: {
-        "intensity": gene_data.raw,
-        "slices": slices[gids[gene]],  # list of integer slice indices
-    }
-    for (gene, gene_data) in gene_voxeldata.items()
-}
-region_map = RegionMap.load_json('input-data/hierarchy_ccfv2_l23split_barrelsplit.json')
-hierarchy_info = utils.get_hierarchy_info(region_map, root='root')
-
-fitting.compute_average_intensities(annotation, gene_marker_volumes, hierarchy_info, region_map)
-breakpoint() # XXX BREAKPOINT
-'''
-
-def compute_average_intensities1(
-    annotation: AnnotationT,
-    gene_marker_volumes: MarkerVolumes,
-    hierarchy_info: pd.DataFrame,
-) -> pd.DataFrame:
-    """
-    Compute the average marker intensity of every region in `hierarchy_info` for every marker
-    of `gene_marker_volumes`.
-
-    If a region does not intersect any of the slices of a gene marker volume, the average density
-    of the marked cell type of this region is set with np.nan.
-
-    Args:
-        annotation: int array of shape (W, H, D) holding the annotation of the whole
-            brain model. (The integers W, H and D are the dimensions of the array).
-        gene_marker_volumes: dict of the form {
-                "gad67": {"intensity": <array>, "slices": <list>},
-                "pv": {"intensity": <array>, "slices": <list>},
-                ...
-                }
-            where each intensity array is of shape (W, H, D) and where the items of each slice
-            list range in [0, W - 1].
-        hierarchy_info: data frame with colums "descendant_ids" (set[int]) and "brain_region"
-            (str) and whose index is a list of region ids.
-            See :fun:`atlas_densities.densities.utils.get_hierarchy_info`.
-
-    Returns:
-        A data frame of the following form (values are fake):
-                    gad67  pv   sst    vip
-        Isocortex   1.5    1.1  0.2    12.0
-        Cerebellum  2.5    0.9  0.1    11.0
-        ...         ...   ...    ...    ...
-        The index of the data frame is the list of regions `hierarchy_info["brain_region"]`.
-        The column labels are the keys of `gene_marker_volumes` in lower case.
-    """
-    region_count = len(hierarchy_info["brain_region"])
-    data = np.full((region_count, len(gene_marker_volumes)), np.nan)
-    hierarchy_info = hierarchy_info.set_index("brain_region")
-    result = pd.DataFrame(
-        data=data,
-        index=hierarchy_info.index,
-        columns=[marker_name.lower() for marker_name in gene_marker_volumes.keys()],
-    )
-
-    L.info(
-        "Computing average intensities for %d markers in %d regions ...",
-        len(gene_marker_volumes),
-        region_count,
-    )
-    for region_name in tqdm(result.index):
-        region_mask = np.isin(annotation, list(hierarchy_info.at[region_name, "descendant_ids"]))
-        for marker, intensity in gene_marker_volumes.items():
-            result.at[region_name, marker.lower()] = compute_average_intensity(
-                intensity["intensity"], region_mask, intensity["slices"]
-            )
-
     return result
 
 

--- a/tests/app/test_mtype_densities.py
+++ b/tests/app/test_mtype_densities.py
@@ -92,10 +92,9 @@ def test_mtype_densities_from_probability_map(tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         td = Path(td)
-        data["annotation"].save_nrrd(td / "annotation.nrrd")
-        with open(td / "hierarchy.json", "w", encoding="utf-8") as file:
-            json.dump(data["hierarchy"], file)
 
+        data["annotation"].save_nrrd(td / "annotation.nrrd")
+        write_json("hierarchy.json", data["hierarchy"])
         data["probability_map01"].to_csv(td / "probability_map01.csv", index=True)
         data["probability_map02"].to_csv(td / "probability_map02.csv", index=True)
 

--- a/tests/densities/test_fitting.py
+++ b/tests/densities/test_fitting.py
@@ -50,7 +50,7 @@ def test_create_dataframe_from_known_densities():
 
 
 @pytest.fixture
-def hierarchy_info():
+def region_map():
     hierarchy = {
         "id": 8,
         "name": "Basic cell groups and regions",
@@ -104,7 +104,11 @@ def hierarchy_info():
         ],
     }
 
-    return utils.get_hierarchy_info(RegionMap.from_dict(hierarchy))
+    return RegionMap.from_dict(hierarchy)
+
+@pytest.fixture
+def hierarchy_info(region_map):
+    return utils.get_hierarchy_info(region_map)
 
 
 def test_fill_in_homogenous_regions(hierarchy_info):
@@ -226,7 +230,7 @@ def test_compute_average_intensity():
     assert actual == 0
 
 
-def test_compute_average_intensities(hierarchy_info):
+def test_compute_average_intensities(region_map, hierarchy_info):
     annotation = np.array(
         [[[0, 976], [976, 936]], [[976, 936], [936, 936]]]  # 976 = Lobule II, 936 = "Declive (VI)""
     )
@@ -261,7 +265,7 @@ def test_compute_average_intensities(hierarchy_info):
         index=hierarchy_info["brain_region"],
     )
 
-    actual = tested.compute_average_intensities(annotation, marker_volumes, hierarchy_info)
+    actual = tested.compute_average_intensities(annotation, marker_volumes, hierarchy_info, region_map)
     pdt.assert_frame_equal(actual, expected)
 
 

--- a/tests/densities/test_fitting.py
+++ b/tests/densities/test_fitting.py
@@ -106,6 +106,7 @@ def region_map():
 
     return RegionMap.from_dict(hierarchy)
 
+
 @pytest.fixture
 def hierarchy_info(region_map):
     return utils.get_hierarchy_info(region_map)
@@ -265,7 +266,9 @@ def test_compute_average_intensities(region_map, hierarchy_info):
         index=hierarchy_info["brain_region"],
     )
 
-    actual = tested.compute_average_intensities(annotation, marker_volumes, hierarchy_info, region_map)
+    actual = tested.compute_average_intensities(
+        annotation, marker_volumes, hierarchy_info, region_map
+    )
     pdt.assert_frame_equal(actual, expected)
 
 


### PR DESCRIPTION
Most of the speed up comes from not having to repeatedly create masks:

old: 1920s
new:
~~2min 26s~~
~~so about 13 times faster~~
10s, so about 192 times faster

Small change in computed densities:
    (Pdb++) np.abs(result.to_numpy() - old.to_numpy()).max()
        9.518734625513225e-08
Test code:
```
from atlas_densities.densities import fitting
from voxcell import VoxelData, RegionMap
from atlas_densities.densities import utils

annotation = VoxelData.load_nrrd('input-data/annotation_ccfv2_l23split_barrelsplit_validated.nrrd')

gene_voxeldata = {
    'gad67': VoxelData.load_nrrd('input-data/gene_gad67_correctednissl.nrrd'),
    'pv': VoxelData.load_nrrd('input-data/gene_pv_correctednissl.nrrd'),
    'sst': VoxelData.load_nrrd('input-data/gene_sst_correctednissl.nrrd'),
    'vip': VoxelData.load_nrrd('input-data/gene_vip_correctednissl.nrrd'),
}
gids = { 'gad67': '479', 'pv': '868', 'sst': '1001', 'vip': '77371835', }
slices = utils.load_json('input-data/realigned_slices.json')
gene_marker_volumes = {
    gene: {
        "intensity": gene_data.raw,
        "slices": slices[gids[gene]],  # list of integer slice indices
    }
    for (gene, gene_data) in gene_voxeldata.items()
}
region_map = RegionMap.load_json('input-data/hierarchy_ccfv2_l23split_barrelsplit.json')
hierarchy_info = utils.get_hierarchy_info(region_map, root='root')

res = fitting.compute_average_intensities(annotation.raw, gene_marker_volumes, hierarchy_info, region_map)
```