### PR TITLE
Speedup mtype density creation from probability maps using voxcell's ValueToIndexVoxels

### DIFF
--- a/atlas_densities/densities/mtype_densities_from_map/create.py
+++ b/atlas_densities/densities/mtype_densities_from_map/create.py
@@ -141,6 +141,7 @@ def create_from_probability_map(  # pylint: disable=too-many-arguments
     returns = Parallel(n_jobs=n_jobs, return_as="generator")(
         delayed(_create_densities_for_metype)(metype) for metype in probability_map.columns
     )
+
     # construct metadata
     output_legend: Dict[str, Dict[str, str]] = defaultdict(dict)
     for return_value in tqdm(returns, total=len(probability_map.columns)):

--- a/atlas_densities/densities/mtype_densities_from_map/create.py
+++ b/atlas_densities/densities/mtype_densities_from_map/create.py
@@ -125,7 +125,7 @@ def create_from_probability_map(  # pylint: disable=too-many-arguments
                 density = annotation_index.ravel(molecular_type_densities[molecular_type])
                 metype_density[region_indices] += density[region_indices] * coefficient
 
-        # reshape the 1d metype_density array  ack to the annotation's shape
+        # reshape the 1d metype_density array back to the annotation's shape
         metype_density = annotation_index.unravel(metype_density)
 
         if np.any(metype_density):

--- a/atlas_densities/densities/mtype_densities_from_map/create.py
+++ b/atlas_densities/densities/mtype_densities_from_map/create.py
@@ -137,7 +137,6 @@ def create_from_probability_map(  # pylint: disable=too-many-arguments
     returns = Parallel(n_jobs=n_jobs, return_as="generator")(
         delayed(_create_densities_for_metype)(metype) for metype in probability_map.columns
     )
-    #returns = [_create_densities_for_metype(metype) for metype in probability_map.columns[0:10]]
     # construct metadata
     output_legend: Dict[str, Dict[str, str]] = defaultdict(dict)
     for return_value in tqdm(returns, total=len(probability_map.columns)):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         # from the HiGHS library. We use the "highs" method in the densities module.
         "scipy>=1.6.0",
         "tqdm>=4.44.1",
-        "voxcell>=3.1.8",  # ValueToIndexVoxels ravel/unravell
+        "voxcell>=3.1.8",  # ValueToIndexVoxels ravel/unravel
     ],
     extras_require={
         "tests": [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         # from the HiGHS library. We use the "highs" method in the densities module.
         "scipy>=1.6.0",
         "tqdm>=4.44.1",
-        "voxcell>=3.1.7",
+        "voxcell>=3.1.8",  # ValueToIndexVoxels ravel/unravell
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
Comparison on 70 nodes:

Before    : 6276s
After       : 60s
Speedup : ~100x

Script used for profiling (Before time was taken from [here](https://bbpgitlab.epfl.ch/dke/apps/blue_brain_atlas_pipeline/-/tree/develop?ref_type=heads#profiling)):
```
from pathlib import Path
from atlas_densities.app import mtype_densities
from click.testing import CliRunner

OUTPUT_DIR = str(Path(__file__).parent / "out")
DATA_DIR = "/gpfs/bbp.cscs.ch/data/project/proj84/atlas_pipeline_runs/2024-03-11T09:54:30/"
CONFIG_DIR = DATA_DIR + "rules_config_dir/mtypes/"
DENSITY_DIR = DATA_DIR + "inhibitory_neuron_densities_linprog_correctednissl_validated/"

arglist = [
    "--log-output-path",
    OUTPUT_DIR,
    "-v",
    "create-from-probability-map",
    "--hierarchy-path", DATA_DIR + "hierarchy_ccfv2_l23split_barrelsplit.json",
    "--annotation-path", DATA_DIR + "annotation_ccfv2_l23split_barrelsplit_validated.nrrd",
    "--probability-map", CONFIG_DIR + "probability_map_L1.csv",
    "--probability-map", CONFIG_DIR + "probability_map_L23.csv",
    "--probability-map", CONFIG_DIR + "probability_map_L4.csv",
    "--probability-map", CONFIG_DIR + "probability_map_L5.csv",
    "--probability-map", CONFIG_DIR + "probability_map_L6.csv",
    "--probability-map", CONFIG_DIR + "probability_map_TH_INH.csv",
    "--marker", "gad67", DENSITY_DIR + "gad67+_density.nrrd",
    "--marker", "pv", DENSITY_DIR + "pv+_density.nrrd",
    "--marker", "sst", DENSITY_DIR + "sst+_density.nrrd",
    "--marker", "vip", DENSITY_DIR + "vip+_density.nrrd",
    "--synapse-class", "INH",
    "--n-jobs", "70",
    "--output-dir", OUTPUT_DIR,
]
print(" ".join(arglist))

res = CliRunner().invoke(
    mtype_densities.app,
    arglist,
    catch_exceptions=False,
    color=True,
)

```