### PR TITLE
Optimize volumetric dataset creation in linprog

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=invalid-name,fixme
+disable=invalid-name,fixme,too-many-positional-arguments
 
 [SIMILARITIES]
 # Minimum lines number of a similarity.

--- a/atlas_densities/densities/inhibitory_neuron_densities_optimization.py
+++ b/atlas_densities/densities/inhibitory_neuron_densities_optimization.py
@@ -46,7 +46,6 @@ import numpy as np
 import pandas as pd
 from atlas_commons.typing import AnnotationT, FloatArray
 from scipy.optimize import linprog
-from tqdm import tqdm
 from voxcell import RegionMap, voxel_data
 
 from atlas_densities.densities import utils


### PR DESCRIPTION
Use voxel indexing to speedup the volume creation at the last step of the linear program.

Running the INH densities rule in atlas pipeline:
```
Before : 2515.45s
After  : 122.5s
```
Introduced a ~20x speedup. 